### PR TITLE
Changed the convention for naming snapshots 

### DIFF
--- a/docs/playbook/exporting-snapshot-to-landing-zone.md
+++ b/docs/playbook/exporting-snapshot-to-landing-zone.md
@@ -51,12 +51,17 @@ Once your pull request has been approved and released to production, you will ne
 - On the sidebar, select `Snapshots`
 - Select `Take snapshot` on the Manual tab
 - On `Take a Snapshot` page, use the `DB Instance` drop down and select the rds instance id as your DB instance
-
-  - In the `Snapshot Name` input field, add a name for your snapshot according to the following convention: `rds_instance_id-dataplatform-YYYY-MM-DD-optional_descriptor`. See example below:
-
-  ```
-  golive-db-dataplatform-2021-05-15
-  ```
+  
+    In the `Snapshot Name` input field, enter a unique name for your snapshot according to the following convention: `dataplatform-YYYY-MM-DD-rds_instance_id`. See example below:
+      
+    ```
+    dataplatform-2021-05-15-golive-db
+    ```
+    
+    If you're creating more than one snapshot to be exported on the same day, you would need to make the snapshot name unique by adding a `snapshot_version` after the date according to the following convention: `dataplatform-YYYY-MM-DD-snapshot_version-rds_instance_id`. For example if this is your second snapshot in the same day, you can name as follows:
+    ```
+    dataplatform-2021-05-15-v2-golive-db
+    ```
 
 - Select `Take snapshot`
 - The snapshot should immediately appear in the `Manual snapshots` list under the `Manual` tab


### PR DESCRIPTION
**What**

- Updated the docs on exporting snapshots to the data platform 
- Changed the naming convention of snapshots to include the date before the instance id and introduce the version number to accommodate for multiple snapshots of the same instance on the same day

**Why**

The `exportTaskIdentifier`, which is used to start an export, is created from the snapshot name except it has a character limit of 60 and since we were previously instructing users to append a date and optional descriptor at the end of this name, these were sometimes being truncated. Therefore, when taking a snapshot on an instance that has a very long instance id such as `addresses-api-db-production-emergency-temp-dataplatform` which is already 55 characters long, this meant that the date at the end was not included due to the 60 character limit and therefore it was no longer unique where multiple snapshots of the same instance were created. As a result, export tasks were failing since it thought an export task already existed for that instance.

This update ensures that each snapshot is uniquely named in the first 60 characters, by adding the date and snapshot version number before the instance id which means the `exportTaskIdentifier` is also unique and will allow export tasks to be started on the correct snapshot.

Co-authored-by: maysakanoni <maysa@madetech.com>