### PR TITLE
add clarity on importing multiple worksheets within same Google sheet

### DIFF
--- a/docs/playbook/google-sheets-import.md
+++ b/docs/playbook/google-sheets-import.md
@@ -25,8 +25,7 @@ tags: playbook
 - The document id is the portion of the url between ``https://docs.google.com/spreadsheets/d/`` and ``/edit#gid=0``. See example below<br />
 
 - You will also need to obtain the worksheet name that you wish to have imported
-- The worksheet name is located at the bottom left of the screen and unless it has been changed or other worksheets added, it will be called `Sheet1`. See example below
-  (screenshot)
+- The worksheet name is located at the bottom left of the screen and unless it has been changed or other worksheets added, it will be called `Sheet1`
 - To import multiple worksheets from the same Google sheet, repeat the instructions in the below section for each worksheet
 
 ## Setting up AWS Glue job


### PR DESCRIPTION
# Description

Added some more clarity to Glue sheets documentation around importing multiple worksheets within the same Google sheet
