### PR TITLE
Initial commit of creating a diagram of Liberator import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install yarn
         run: npm install yarn -g
+      - name: Install PlantUML
+        run: sudo apt-get install plantuml
       - name: Install Packages
         run: yarn install
+      - name: Build diagrams
+        run: make -C diagrams
       - name: Build page
         run: yarn run build
       - name: Deploy to gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Deployment
-on:
-  push:
-    branches:
-      - main
+on: push
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,8 +22,3 @@ jobs:
         run: make -C diagrams
       - name: Build page
         run: yarn run build
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./build

--- a/diagrams/.gitignore
+++ b/diagrams/.gitignore
@@ -1,0 +1,2 @@
+structurizr-*.png
+structurizr-*.puml

--- a/diagrams/Makefile
+++ b/diagrams/Makefile
@@ -2,4 +2,4 @@ structurizr-Liberator-Container.png: structurizr-Liberator-Container.puml
 	plantuml structurizr-Liberator-Container.puml
 
 structurizr-Liberator-Container.puml: structurizr/liberator-import.dsl
-	docker run -it --rm -v $${PWD}:/usr/local/structurizr structurizr/cli export -w ./structurizr/liberator-import.dsl -o . -f plantuml/c4plantuml
+	docker run --rm -v $${PWD}:/usr/local/structurizr structurizr/cli export -w ./structurizr/liberator-import.dsl -o . -f plantuml/c4plantuml

--- a/diagrams/Makefile
+++ b/diagrams/Makefile
@@ -1,0 +1,5 @@
+structurizr-Liberator-Container.png: structurizr-Liberator-Container.puml
+	cat structurizr-Liberator-Container.puml |  docker run --rm -i think/plantuml -tpng > structurizr-Liberator-Container.png
+
+structurizr-Liberator-Container.puml: structurizr/liberator-import.dsl
+	docker run --rm -v $${PWD}:/home gilbertotcc/structurizr:latest export -w ./structurizr/liberator-import.dsl -o . -f plantuml/c4plantuml

--- a/diagrams/Makefile
+++ b/diagrams/Makefile
@@ -1,5 +1,5 @@
 structurizr-Liberator-Container.png: structurizr-Liberator-Container.puml
-	cat structurizr-Liberator-Container.puml |  docker run --rm -i think/plantuml -tpng > structurizr-Liberator-Container.png
+	plantuml structurizr-Liberator-Container.puml
 
 structurizr-Liberator-Container.puml: structurizr/liberator-import.dsl
-	docker run --rm -v $${PWD}:/home gilbertotcc/structurizr:latest export -w ./structurizr/liberator-import.dsl -o . -f plantuml/c4plantuml
+	docker run -it --rm -v $${PWD}:/usr/local/structurizr structurizr/cli export -w ./structurizr/liberator-import.dsl -o . -f plantuml/c4plantuml

--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -1,0 +1,5 @@
+## Creating the diagram
+
+You will need `structurizr-cli`, and `plant-uml` installed.
+
+After which you can run `make`, to generate the diagram.

--- a/diagrams/structurizr/liberator-import.dsl
+++ b/diagrams/structurizr/liberator-import.dsl
@@ -1,0 +1,61 @@
+workspace "Getting Started" "This is a model of my software system." {
+    model {
+        liberatorSFTP = softwareSystem "Liberator SFTP" "Contains nightly exports of liberator data"
+
+        enterprise "Hackney Data Platform" {
+            parkingAnalyst = person "Analyst" "Parking Analyst"
+            athena = softwareSystem "AWS Athena"
+            landingZone = softwareSystem "Landing Zone" "Data Platform Landing Zone" {
+                landingZoneBucket = container "Bucket" "" "S3"
+            }
+            refinedZone = softwareSystem "Refined Zone" "Data Platform Refined Zone"
+
+            liberatorImport = softwareSystem "Liberator importer" {
+                dbSnapshotToS3 = container "DB Snapshot to Parquet" "Data Platform module for converting an RDS database to Parquet"
+                liberatorMysql = container "Transitionary DB" "Database used for ingesting the dump" "RDS MySQL" "Database"
+                liberatorZipStore = container "Liberator bucket" "Historical liberator dump storage" "S3 Bucket"
+                liberatorSFTPDownloader = container "Liberator Downloader" "AWS Lambda function to download the latest liberator dump" "Lambda/Node.JS"
+                flatFileExtractor = container "Liberator extractor" "Extracts the mysql dump, ingests the data into an RDS instance" "Fargate/ECS/Bash"
+
+                liberatorSFTPDownloader -> liberatorSFTP "Downloads export nightly"
+                liberatorSFTPDownloader -> liberatorZipStore "Saves to"
+
+                flatFileExtractor -> liberatorZipStore "Downloads zip"
+                flatFileExtractor -> liberatorMysql "Imports into MySQL"
+
+                dbSnapshotToS3 -> liberatorMysql "Gets data from"
+                dbSnapshotToS3 -> landingZone "Pushes data to"
+            }
+
+            glue = softwareSystem "AWS Glue" {
+                
+            }
+        }
+    }
+
+    views {
+        container liberatorImport "Liberator-Container" "Liberator import" {
+            include *
+        }
+
+        styles {
+            element "Container" {
+                shape RoundedBox
+            }
+            element "Software System" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Person" {
+                shape person
+                background #08427b
+                color #ffffff
+            }
+            element "Database" {
+                shape Cylinder
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
# Description

This commit shows how we can use Structurizr to generate version-controlled diagrams of the Data Platform.

Further improvements might include:
* Multiple diagram types, at varying levels of detail, see [C4 Model](https://c4model.com/).
* Building diagrams as part of the pipeline
* Including diagrams in the playbook website

## Diagram render
![structurizr-Liberator-Container](https://user-images.githubusercontent.com/976274/122188050-814ac580-ce87-11eb-81ef-a9b465fa3b40.png)
