### PR TITLE
Reference the raw zone in place of landing zone for liberator data

### DIFF
--- a/docs/playbook/scheduling-liberator-glue-jobs.md
+++ b/docs/playbook/scheduling-liberator-glue-jobs.md
@@ -7,14 +7,14 @@ tags: playbook
 
 ## Intro
 
-This guide will step you through how to schedule a glue job, from the AWS console, that runs on the liberator data in the [landing zone][landing_zone].
+This guide will step you through how to schedule a glue job, from the AWS console, that runs on the liberator data in the [raw zone][raw_zone].
 
 Scheduling your glue job will mean that it will run whenever new liberator data is added in the data platform so that your
 transformed data in, say, the [refined zone][refined_zone] is based on the most up to date data, with no manual intervention.
 
 ## Prerequisites
 
-* You have created a glue job that transforms the liberator data in the [landing zone][landing_zone]. There is guidance on [creating a glue job][creating_a_glue_job] and a [workshop][workshop] if you need help with this.
+* You have created a glue job that transforms the liberator data in the [raw zone][raw_zone]. There is guidance on [creating a glue job][creating_a_glue_job] and a [workshop][workshop] if you need help with this.
 * You have access to the Hackney Data Platform
 
 ## Steps
@@ -42,7 +42,7 @@ This is so that the job will update the tables in [AWS Athena][aws_athena] after
 
 - Click "Add". Your job should appear in the diagram, connected to the trigger.
 
-Your job is now scheduled to run when new liberator data is added to the landing zone.
+Your job is now scheduled to run when new liberator data is added to the platform.
 
 
 ## Creating a trigger to start liberator glue jobs
@@ -51,11 +51,11 @@ Your job is now scheduled to run when new liberator data is added to the landing
 - Click on the "Add new" tab, put `trigger-liberator-jobs` in the Name field then click "Add'.
 A new diamond shape will appear in the diagram with a broken link symbol, this is the trigger you have just added and it now needs to be linked to the rest of the workflow.
 - Click on the shape, then on the "Action" dropdown and select "Add jobs/crawlers to watch".
-Click on the "Crawlers" tab. Select the crawler `dataplatform-{environment}-landing-zone-liberator` from, then list then click "Add".
+Ensure the "Jobs" tab is selected. Select the job `Copy parking Liberator landing zone to raw` from, then list then click "Add".
 - Continue following the instructions above.
 
 [aws_glue_workflows]: https://eu-west-2.console.aws.amazon.com/glue/home?region=eu-west-2#etl:tab=workflows;workflowView=workflow-list
-[landing_zone]: ../zones.md#landing-zone
+[raw_zone]: ../zones.md#raw-zone
 [refined_zone]: ../zones.md#refined-zone
 [aws_glue_triggers]: https://eu-west-2.console.aws.amazon.com/glue/home?region=eu-west-2#etl:tab=triggers
 [aws_glue_studio]: https://eu-west-2.console.aws.amazon.com/gluestudio/home?region=eu-west-2#/jobs

--- a/docs/workshop/aws_glue_studio_parking.md
+++ b/docs/workshop/aws_glue_studio_parking.md
@@ -7,7 +7,7 @@ layout: layout
 
 ## Prerequisities
 
-* Have access to the Parking Liberator Landing zone.
+* Have access to the Parking Liberator Raw zone.
 * Have experience with writing SQL queries in [AWS Athena][aws_athena] already.
 * Have experience running AWS Glue Crawlers.
 
@@ -55,7 +55,7 @@ Create an SQL query for [AWS Athena][aws_athena_console] which extracts, and agg
 a resultset with the below format.
 
 The data platform provides source data within the table
-  `"dataplatform-stg-liberator-landing-zone"."liberator_permit_renewals"`.
+  `"dataplatform-stg-liberator-raw-zone"."liberator_permit_renewals"`.
 
 You will want to convert VARCHAR columns to [appropriate AWS Athena data types][athena_data_types].
 Specifically, the time columns should have a TIMESTAMP type.
@@ -102,7 +102,7 @@ SELECT
       MIN(DATE_PARSE(NULLIF(renewal_start_date, ''), '%Y-%m-%d %H:%i:%S')) AS earliest_start_date,
       COUNT(*) AS number_of_renewals,
       import_year, import_month, import_day, import_date
-FROM "dataplatform-stg-liberator-landing-zone"."liberator_permit_renewals"
+FROM "dataplatform-stg-liberator-raw-zone"."liberator_permit_renewals"
 GROUP BY permit_reference, import_year, import_month, import_day, import_date
 ```
 </details>
@@ -111,7 +111,7 @@ GROUP BY permit_reference, import_year, import_month, import_day, import_date
 ## Moving your query to AWS Glue Studio
 
 Once you have written, and seen a successful execution of your query in AWS Athena, we can move onto
-creating an AWS Glue Job which will transform and copy the `dataplatform-stg-landing-zone` data
+creating an AWS Glue Job which will transform and copy the `dataplatform-stg-raw-zone` data
 into the `dataplatform-stg-refined-zone`.
 
 Turning our first query into a Glue Job which transforms the data into a new dataset, will allow us
@@ -122,7 +122,7 @@ We will first create a new AWS Glue Studio job by following a modified version o
 * For the environment, we'll be using `stg`.
 * For the __Data source__ node, we'll select __Data catalogue table__ for "S3 source type"
   under the "Data source properties" tab.
-  Then choosing `dataplatform-stg-liberator-landing-zone` and `liberator_permit_renewals`
+  Then choosing `dataplatform-stg-liberator-raw-zone` and `liberator_permit_renewals`
   for Database and Table respectively.
 * For the __Data target__ node:
   1. Set the Format to "Glue Parquet"
@@ -157,7 +157,7 @@ our SQL created above.
    The Spark SQL executor will only accept a single SQL query, and that query mustn't have
    a trailing semicolon.
 1. Change the value of "Spark SQL aliases" to `liberator_permit_renewals`, and remove any usage of a
-   database prefix `dataplatform-stg-liberator-landing-zone` from the SQL query inside of the "Code Block".
+   database prefix `dataplatform-stg-liberator-raw-zone` from the SQL query inside of the "Code Block".
    If your query joined multiple tables, each table would need a distinct "Data Source" linked
    to the "Spark SQL" node.
 1. Click the __Save__ button, followed by the __Run__ button.


### PR DESCRIPTION
We have added a job that moves liberator data from the landing zone
to the raw zone, removing unneeded data.