### PR TITLE
Suggested edits to structure and clarification fixes

### DIFF
--- a/docs/playbook/onboarding-new-users-to-the-platform.md
+++ b/docs/playbook/onboarding-new-users-to-the-platform.md
@@ -1,36 +1,52 @@
 ---
-title: Onboarding new users to the platform
+title: Onboarding new users and departments to the platform
 description: "How to add users to a Google group or add a new group for a department."
 layout: playbook_js
 tags: [playbook]
 ---
 
+## Objective
+
+Before a user or department is able to use the data platform, their details must be configured and setup beforehand by a Data Platform Engineer.
+
+## Intended audience
+
+- Data Platform Engineer
 
 ## Prerequisites
 
 - You need to be a manager of the relevant Google group
 - The user you would like to add to the Google group has a Hackney GSuite account
 
-### Adding a user to a department
+## Adding a user to a department already on the platform
 
-- To add a user to a Google group, follow the instructions [here][add_user_google_group]
-- If you would like the user to receive AWS email notifications, then ensure you set their subscription preference to "Each email" (see [section 5.2][membership_settings] of this guide)
-- This can take up to two hours to sync with AWS
+:::note
+Adding a new user can take up to two hours to sync with AWS.
+:::
+
+To add a user to a Google group, follow the instructions [here][add_user_google_group].
+
+:::tip
+If you would like the user to receive AWS email notifications, then ensure you set their subscription preference to "Each email" (see [section 5.2][membership_settings] of this guide)
+:::
 
 [add_user_google_group]: https://support.google.com/groups/answer/2465464?hl=en
 
-### Creating a department on the Data Platform
+## Adding a department onto the platform
 
-- Create a Google group, with the name `saml-aws-data-platform-collaborator-${department_name}` as a template
-  - You can do this by contacting the Hackney Service team via the [`ask-devops` Slack channel][ask_devops_slack]
-  - Ensure you specify at least one manager for the group you are creating. This person is responsible for adding/removing
+1. Create a Google group, with the name `saml-aws-data-platform-collaborator-${department_name}` as a template
+   - You can do this by contacting the Hackney Service team via the [`ask-devops` Slack channel][ask_devops_slack]
+   - Ensure you specify at least one manager for the group you are creating. This person is responsible for adding/removing
     users to your department
-  - Enable the collaborative inbox feature on your Google group by following step 2 in this [guide][collaborative_inbox].
+   - Enable the collaborative inbox feature on your Google group by following step 2 in this [guide][collaborative_inbox].
   This will allow your group and its members to receive emails from outside the Hackney organisation as you will need to be able to receive AWS email notifications
-- Wait for 2 hours for the next AWS sync before moving onto the next step
-- Create a new department using the [existing resources][department.tf] as a template
-  - Specify `google_group_display_name` with the email address of the Google group you created earlier
-  - Specify a unique name for the department, with a maximum of 16 characters
+2. Wait for 2 hours for the next AWS sync before moving onto the next step
+3. Create a new department using the [existing resources][department.tf] as a template
+   - Specify `google_group_display_name` with the email address of the Google group you created earlier
+   - Specify a unique name for the department, with a maximum of 16 characters
+4. Submit a pull request on GitHub, and await approval from two other Data Platform Engineer's.
+5. Before merging, which will automatically apply the Terraform changes, it is intended that a Data Platform Engineer would first check that the pipeline and all required actions are clear.
+6. Once Terraform has applied, an email address will be output, which can be retrieved from either the GitHub Actions output, or from within the GSuite admin. This email address can be shared with the department that you are onboardeding, which they can then use to ingest data into the platform.
 
 [department.tf]: https://github.com/LBHackney-IT/Data-Platform/blob/main/terraform/05-departments.tf
 [ask_devops_slack]: https://hackit-lbh.slack.com/archives/C01FX9ERRSL

--- a/docs/playbook/querying-data-using-sql.md
+++ b/docs/playbook/querying-data-using-sql.md
@@ -1,11 +1,19 @@
 ---
-title: Querying the Platform using SQL
+title: Querying the Data Platform using SQL within AWS Athena
 description: "AWS Athena to query data in S3"
 layout: playbook_js
 tags: [playbook]
 ---
 
-## Intro
+## Objective
+
+To be able to query data within the Data Platform using SQL.
+
+## Intended audience
+
+- Data Analyst
+
+## Background
 
 The Data Platform provides AWS Athena as the tool to execute SQL queries against the data within the platform.
 
@@ -25,9 +33,7 @@ You'll want to make sure that your region is currently set to London, in AWS thi
 
 ![AWS Console region selector](images/region-selector.png)
 
-Then you'll want to ensure that you are switched to the Athena Workgroup for your department.
-You can check your current workgroup by hovering over the workgroup tab displayed at the top of the Athena page.
-If the workgroup isn't correct then [switch your workgroup][switch_workgroup] to the one you were given before proceeding.
+Then you'll want to ensure that you are switched to the Athena Workgroup for your department. You can check your current workgroup by hovering over the workgroup tab displayed at the top of the Athena page. If the workgroup isn't correct then [switch your workgroup][switch_workgroup] to the one you were given before proceeding.
 
 [switch_workgroup]: https://docs.aws.amazon.com/athena/latest/ug/workgroups-create-update-delete.html#switching-workgroups
 


### PR DESCRIPTION
Propose the following to playbook guides:

- Add **Objective** heading - clearly outlining the purpose of the guide, and what the intended audience can achieve by following it
- Add **Intended audience** heading - who is this playbook for?
- Use numbered lists for sets of instructions for easier reference and tracking of progress

I've also proposed a few formatting changes intended to make it easier for those less-familiar with the Data Platform, and some clarifications based on a number of run-throughs I did with James on the platform.