### PR TITLE
Add instructions on Glue job and Crawler to workflow and trigger to schedule crawler

### DIFF
--- a/docs/playbook/ingesting-data/005-database-ingestion.md
+++ b/docs/playbook/ingesting-data/005-database-ingestion.md
@@ -153,13 +153,20 @@ _For more technical details on the overall process, see: [Database Ingestion doc
     The Data Platform team needs to approve any changes to the code that you make, so your change won't happen automatically.
 
 7. Once you get confirmation that the code has been successfully deployed,
-you will need to retrieve the ID of the security group for the JDBC Connection (created as part of this module), and request that it is
-added to the source database's inbound security group rules by the appropriate engineer.
-
-**To find the security group ID of your connection:**
-- Navigate to `AWS Glue` in the AWS Console, then click `Connections` in the left-hand navigation bar and search for your connection.
-    It will have the same name that you set in the **name** input variable above.
-- Click on your connection and copy the ID next to `Security groups` e.g. `sg-05a4fc711d3e12345`.
+you will need to do the following before moving on to the next section:
+   - Request that the ID of the security group of the Glue JDBC Connection (created in this module) is added to the source database's inbound security group rules by an appropriate engineer.
+     
+     - You can find the security group ID of your connection by navigating to `AWS Glue` in the AWS Console, 
+       then clicking `Connections` in the left-hand navigation bar and then searching for your connection.
+        It will have the same name that you set in the **name** input variable above.
+       
+     - Click on your connection and copy the ID next to `Security groups` e.g. `sg-05a4fc711d3e12345`.
+      
+    - Test your connection and ensure it works:
+        - Select your connection and click `Test Connection`.
+        - Assign the relevant department IAM role.
+          - **Note: If the data you are ingesting is not department specific, you should use the IAM role: `dataplatform-stg-glue-role`.**
+        - Lastly, click `Test Connection` (this can take up to a minute to complete).
  
 ### Create a Glue job and Crawler 
 Once your Pull Request for setting up the JDBC Connection has been approved and deployed, you can continue with this section.

--- a/docs/playbook/ingesting-data/005-database-ingestion.md
+++ b/docs/playbook/ingesting-data/005-database-ingestion.md
@@ -145,7 +145,11 @@ _For more technical details on the overall process, see: [Database Ingestion doc
         ```
         database_secret_name = "database-credentials/lbhatestrbviews-council-tax"
         ```
-  
+
+    - **schema_name** (optional): Name of schema in the database containing tables to be ingested. e.g. `"parking"`.
+      
+      For databases that support schemas, you can provide a schema name here to ingest all tables in the schema within the specified database.
+      Oracle Database and MySQL don’t support this; therefore **DO NOT** enter a value here.
 
 6. Commit your changes and create a Pull Request for review by the Data Platform team. 
    You should wait for it to be approved and deployed before moving onto the next step.


### PR DESCRIPTION
- add instructions on adding glue job and crawler to workflow, triggering glue job and running on a schedule
- add instructions to find Glue JDBC connection security group ID and add to inbound rules of source database's security group
- add instructions to test connection before proceeding to creating the ingestion Glue job 
