### PR TITLE
Add `create_starting_trigger` input variable for glue module

### DIFF
--- a/docs/playbook/transforming-data/using-aws-glue/002-deploy-glue-jobs.md
+++ b/docs/playbook/transforming-data/using-aws-glue/002-deploy-glue-jobs.md
@@ -161,8 +161,8 @@ _If a variable is not needed you should delete the entire line in the module blo
     - You can use [this tool][cron-expression-generator] to generate your Cron expressions.
   
   - **create_starting_trigger** (optional): Defaults to `true`.
-    If you do not wish to create a starting trigger, or you're manually adding another trigger to your Glue job which already has a starting trigger, you should set this to `false`.
-    Conflicts with **triggered_by_job**, **triggered_by_crawler**, **schedule**. 
+    If you do not wish to create a starting trigger, or you're manually adding another trigger to your Glue job which is part of a workflow and already has a starting trigger, you should set this to `false`.
+    If this is set to `false`, you can't set the following input variables; **triggered_by_job**, **triggered_by_crawler**, **schedule**. 
   
 
 - **job_description** (optional): A description of the AWS Glue job e.g. "Exports Google Sheets imported datasets to the landing zone"

--- a/docs/playbook/transforming-data/using-aws-glue/002-deploy-glue-jobs.md
+++ b/docs/playbook/transforming-data/using-aws-glue/002-deploy-glue-jobs.md
@@ -159,6 +159,11 @@ _If a variable is not needed you should delete the entire line in the module blo
       ```
 
     - You can use [this tool][cron-expression-generator] to generate your Cron expressions.
+  
+  - **create_starting_trigger** (optional): Defaults to `true`.
+    If you do not wish to create a starting trigger, or you're manually adding another trigger to your Glue job which already has a starting trigger, you should set this to `false`.
+    Conflicts with **triggered_by_job**, **triggered_by_crawler**, **schedule**. 
+  
 
 - **job_description** (optional): A description of the AWS Glue job e.g. "Exports Google Sheets imported datasets to the landing zone"
 - **extra_jars** (optional): If your Glue job requires extra packages that are zipped in a JAR file, you can provide the list of the S3 path(s) to the JAR file(s) here.


### PR DESCRIPTION
- Enables you to add multiple dynamic triggers to a Glue job which are separate from the Glue job module
