### PR TITLE
removed link to Google doc for..

### DIFF
--- a/docs/playbook/training-modules/Module-0.md
+++ b/docs/playbook/training-modules/Module-0.md
@@ -88,7 +88,6 @@ For the Data Platform, it will have the packages installed to be quite similar t
 
 The notebooking tool uses your local resources to execute the code, meaning you don’t consume AWS resources, saving Hackney money.
 Feedback on errors is a lot quicker, and as a result is a lot easier to debug. This makes it more efficient for developing code.
-To set up the notebooking environment, follow the instructions [here](https://docs.google.com/document/d/1QEgDFydQS34Ssmx26c0qUM9aZAZ36r1A9X5Dqe_7ub4)
 
 ### Amazon Web Services (AWS)
 


### PR DESCRIPTION
...'setting up a notebooking environment' - there is a specific Playbook link in the 'How to set up tools' section instead.

# Description

Please include a summary of the proposed changes
