### PR TITLE
DP-586 - Sidebar padding leads to text wrap around which then pushes other page down and hidden, without padding scroll bar and dropdown work correctly

### DIFF
--- a/src/docs.scss
+++ b/src/docs.scss
@@ -83,3 +83,7 @@ html[data-theme="dark"] .navbar__logo {
   position: sticky;
   left: var(--ifm-pre-padding);
 }
+
+.menu_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocSidebar-styles-module {
+  padding: 0.0rem !important;
+}


### PR DESCRIPTION
**Before:**

https://user-images.githubusercontent.com/81559982/165498624-651fd541-5548-454f-9ab0-670d674fa150.mov




**After:**


https://user-images.githubusercontent.com/81559982/165498753-433067df-3696-4d7d-abd0-1f43c18a5724.mov


