### PR TITLE
Add instructions for running the landing to raw copy job for RingGo manually

### DIFF
--- a/docs/docs/ringgo-ingestion.md
+++ b/docs/docs/ringgo-ingestion.md
@@ -31,6 +31,23 @@ To run the Lambda manually the following test body can be used in the Lambda con
 
 Please note that files are uploaded to the server each afternoon and they contain data for previous day, so the files are lacking behind by a day.
 
+### Copying missing data from landing to raw zone in case of a failure
+
+If for any reason there's a gap in dates in the raw zone data due to ingestion failure the raw to landing copy job has to be run manually.
+
+Once the missing data has been ingested to the landing zone please follow these steps:
+
+1. Clear the `dataplatform-{ENVIRONMENT}-raw-zone/parking/ringgo/sftp/` folder by deleting all folders and files in there
+2. Open the `Parking copy RingGo SFTP data to raw` job in the Glue console
+3. Reset the bookmark for the job
+4. Comment out the `latest_data = get_latest_partitions(data_source)` line in the script. Currently on line 27.
+5. Uncomment the `# latest_data = data_source` line below (28)
+6. Save the job
+7. Run the job
+8. Revert the changes in steps 4. and 5. and save the job again
+
+Raw zone should now have the data matching the landing zone 
+
 ### Failure alerts
 
 The Lambda function is configured to send failure alerts to central `data-platform-lambda-alerts` Google space.


### PR DESCRIPTION
# Description

Add instructions on how to run the landing to raw copy job manually in case there are gaps in the data in the raw zone.
