### PR TITLE
updated backdated liberator ingestion docs

### DIFF
--- a/docs/docs/backdated-liberator-ingestion.md
+++ b/docs/docs/backdated-liberator-ingestion.md
@@ -20,20 +20,23 @@ Open Cloudwatch and search for `liberator-to-rds-snapshot-event` and disable the
 #### 2. Trigger the ECS task to start the backdated ingestion process
 
 * Open ECS and in `Task Definitions` select `liberator-to-rds-snapshot`
-* Click on the `Actions` dropdown and select `Run Task`
+* Click on the `Deploy` dropdown and select `Run Task`
 * This next page includes a lot of options, unless specified below leave all options as they are:
-    * Cluster: `dataplatform-prod-workers`
+    * Exisiting Cluster: `dataplatform-prod-workers`
     * Launch Type: `FARGATE`
-    * Operating System Family: `Linux`
-    * Cluster VPC: Select the one VPC available
+    * Platform Version: `LATEST`
+* Expand the `Networking` tab
+    * VPC: Select the one VPC available
     * Subnets: Select all subnets available one by one
-    * Auto-assign public IP: `DISABLED`
-    * Expand the `Advanced options` section:
-        * In `Container Overrides` expand the `liberator-to-rds-snapshot` section:
-            * Click on  `Add Environment Variable`
-            * Set the key to `IMPORT_DATE_OVERRIDE`
-            * Set the value to the date used in the liberator dump file you wish to ingest. This date must be in the following format: yyyy-mm-dd eg. 2022-06-01
-* Click `Run Task` at the bottom of the page
+    * Public IP: `Turned off`
+* Expand the `Container overrides` section:
+    * Expand the `liberator-to-rds-snapshot` section:
+        * Click on  `Add Environment Variable`
+        * Set the key to `IMPORT_DATE_OVERRIDE`
+        * Set the value to the date used in the liberator dump file you wish to ingest. This date must be in the following format: yyyy-mm-dd eg. 2022-06-01
+* Click `Create` at the bottom of the page
+
+This can take a long time to run (>1hr), the logs for the task will output `Done` when the task is complete. 
 
 #### 3. Automated ingestion of backdated liberator data starts
 
@@ -49,6 +52,7 @@ zone into the raw zone in the correct partition. This glue workflow is called `p
 When finished the backdated liberator data will be ingested into the raw zone 
 in the partition date that matches the `IMPORT_DATE_OVERIDE` environment variable that you input in step 2
 
+These onward tasks will also take a long time (>1hr) to complete.
 #### 4. Enable Cloudwatch s3 event trigger (optional)
 
 Please enable the cloudwatch trigger that you disabled in step 1. This is very important otherwise the next days liberator ingestion will not happen

--- a/docs/docs/backdated-liberator-ingestion.md
+++ b/docs/docs/backdated-liberator-ingestion.md
@@ -28,6 +28,7 @@ Open Cloudwatch and search for `liberator-to-rds-snapshot-event` and disable the
 * Expand the `Networking` tab
     * VPC: Select the one VPC available
     * Subnets: Select all subnets available one by one
+    * Security group: select `Use an existing security group` then select `liberator-to-rds-snapshot` from the drop down
     * Public IP: `Turned off`
 * Expand the `Container overrides` section:
     * Expand the `liberator-to-rds-snapshot` section:


### PR DESCRIPTION
This updates the instructions for ingesting backdated Liberator extracts to reflect changes made to the ECS UI. 
