### PR TITLE
Bump Node version in Actions to fix broken build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.20.0]
+        node-version: [20.18.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install yarn


### PR DESCRIPTION
The old version was too... old

The upgrade PR that's just been merged [failed to deploy](https://github.com/LBHackney-IT/Data-Platform-Playbook/actions/runs/11478053563/job/31941436204) with the following error:

```bash
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error @docusaurus/core@3.5.2: The engine "node" is incompatible with this module. Expected version ">=18.0". Got "16.20.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

Node 20 is the current LTS, so this PR bumps the version to that.
