### PR TITLE
DL 218 onboarding demo for local testing using aws profile

### DIFF
--- a/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
+++ b/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
@@ -1,0 +1,103 @@
+---
+title: Read universal_calendar and write a demo parquet table
+description: "Simple Windows example for reading universal_calendar, aggregating it, writing Parquet to S3, and registering a Glue table."
+layout: playbook_js
+tags: [playbook]
+---
+
+## Goal
+
+Read from:
+
+```sql
+"unrestricted-raw-zone"."universal_calendar"
+```
+
+Write parquet to:
+
+```text
+s3://dataplatform-stg-refined-zone/data-and-insight/testing/demo/test_tian_demo_calendar/
+```
+
+The generated parquet file name will start with `test_tian_demo_calendar_`.
+
+Register this Glue catalog table:
+
+```text
+"data-and-insight-refined-zone"."test_tian_demo_calendar"
+```
+
+The table name is fixed in the script as `test_tian_demo_calendar`.
+
+## 1. Configure the AWS profile on Windows
+
+Open this file:
+
+```powershell
+notepad C:\Users\<your_windows_username>\.aws\config
+```
+
+If the `.aws` folder or `config` file does not exist, create it.
+
+Add this profile:
+
+```ini
+[profile DataPlatformDataAndInsightStg]
+sso_start_url = https://hackney.awsapps.com/start
+sso_region = eu-west-1
+sso_account_id = 120038763019
+sso_role_name = DataPlatformDataAndInsightStg
+region = eu-west-2
+output = json
+```
+
+Then log in:
+
+```powershell
+aws sso login --profile DataPlatformDataAndInsightStg
+```
+
+Check the login works:
+
+```powershell
+aws sts get-caller-identity --profile DataPlatformDataAndInsightStg
+```
+
+## 2. Install the Python packages
+
+```powershell
+py -m pip install awswrangler boto3
+```
+
+## 3. Check the Python script
+
+The runnable script is stored next to this page:
+
+```text
+docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
+```
+
+It is safe to run more than once:
+
+- It writes only to the S3 folder for its own `TABLE_NAME`.
+- It clears that folder before writing.
+- It uses `mode="overwrite"` so the Glue catalog table is replaced each run.
+- It uses `logging`, not `print`, so the run output is clear.
+
+## 4. Run it
+
+```powershell
+cd C:\Users\<your_windows_username>\repos\Data-Platform-Playbook\docs\playbook\onboard-etl-at-dap
+py .\universal_calendar_demo.py
+```
+
+## 5. Check the result in Athena
+
+Use the same table name that you put in the script:
+
+```sql
+SELECT *
+FROM "data-and-insight-refined-zone"."test_tian_demo_calendar"
+ORDER BY calendar_year
+LIMIT 10;
+```

--- a/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
+++ b/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
@@ -80,6 +80,7 @@ docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
 It is safe to run more than once:
 
 - It writes only to the S3 folder for its own `TABLE_NAME`.
+- It stores temporary Athena query output under `s3://dataplatform-stg-athena-storage/data-and-insight/`.
 - It clears that folder before writing.
 - It uses `mode="overwrite"` so the Glue catalog table is replaced each run.
 - It uses `logging`, not `print`, so the run output is clear.

--- a/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
+++ b/docs/playbook/onboard-etl-at-dap/001-read-universal-calendar-and-write-parquet.md
@@ -66,7 +66,7 @@ aws sts get-caller-identity --profile DataPlatformDataAndInsightStg
 ## 2. Install the Python packages
 
 ```powershell
-py -m pip install awswrangler boto3
+pip install awswrangler boto3
 ```
 
 ## 3. Check the Python script

--- a/docs/playbook/onboard-etl-at-dap/002-homework-partitioned-calendar-aggregate.md
+++ b/docs/playbook/onboard-etl-at-dap/002-homework-partitioned-calendar-aggregate.md
@@ -7,31 +7,21 @@ tags: [playbook]
 
 ## Goal
 
-Create a new Python script that reads:
+Create a second script that:
 
-```sql
-"unrestricted-raw-zone"."universal_calendar"
-```
+- reads `"unrestricted-raw-zone"."universal_calendar"`
+- creates a monthly aggregate
+- writes to `s3://dataplatform-stg-refined-zone/data-and-insight/testing/demo/`
+- registers a new table in `"data-and-insight-refined-zone"`
+- partitions the output by `["import_year", "import_month", "import_day", "import_date"]`
 
-Write a different aggregate to:
-
-```text
-s3://dataplatform-stg-refined-zone/data-and-insight/testing/demo/test_<your_name>_demo_calendar_monthly_partitioned/
-```
-
-Register this new Glue catalog table in the same database:
-
-```text
-"data-and-insight-refined-zone"."test_<your_name>_demo_calendar_monthly_partitioned"
-```
-
-Use your own name in the table name. For example, if your name is Jane Smith, use `test_jane_smith_demo_calendar_monthly_partitioned`. Do not use `tian` unless your name is Tian.
-
-The output must be partitioned by:
+Use your own name in the table name. For example, Jane Smith should use:
 
 ```python
-["import_year", "import_month", "import_day", "import_date"]
+TABLE_NAME = "test_jane_smith_demo_calendar_monthly_partitioned"
 ```
+
+Do not use `tian` unless your name is Tian.
 
 ## Task
 
@@ -41,29 +31,28 @@ Copy `universal_calendar_demo.py` into a new file:
 universal_calendar_homework.py
 ```
 
-Change the table constants:
+Change these values:
 
 ```python
 TABLE_NAME = "test_your_name_demo_calendar_monthly_partitioned"
 PARTITION_COLUMNS = ["import_year", "import_month", "import_day", "import_date"]
 ```
 
-Use this different aggregate query:
+Change the SQL so it aggregates by year and month:
 
 ```sql
 SELECT
   year(CAST(date_iso AS timestamp)) AS calendar_year,
   month(CAST(date_iso AS timestamp)) AS calendar_month,
   count(*) AS day_count,
-  sum(CASE WHEN bank_holiday_flag THEN 1 ELSE 0 END) AS bank_holiday_count,
-  sum(CASE WHEN holiday_flag THEN 1 ELSE 0 END) AS holiday_count
+  sum(CASE WHEN bank_holiday_flag THEN 1 ELSE 0 END) AS bank_holiday_count
 FROM "unrestricted-raw-zone"."universal_calendar"
 WHERE date_iso IS NOT NULL
 GROUP BY 1, 2
 ORDER BY 1, 2
 ```
 
-After reading the data into `df`, add these import partition columns:
+Before writing the parquet, add the partition columns:
 
 ```python
 from datetime import date
@@ -75,49 +64,30 @@ df["import_day"] = today.day
 df["import_date"] = today.isoformat()
 ```
 
-Update the `wr.s3.to_parquet` call so it writes partitions:
+Add this line to `wr.s3.to_parquet`:
 
 ```python
-result = wr.s3.to_parquet(
-    df=df,
-    path=target_prefix,
-    index=False,
-    dataset=True,
-    mode="overwrite",
-    database=TARGET_DATABASE,
-    table=TABLE_NAME,
-    partition_cols=PARTITION_COLUMNS,
-    filename_prefix=f"{TABLE_NAME}_",
-    boto3_session=session,
-)
+partition_cols=PARTITION_COLUMNS,
 ```
 
-## Check Your Work
+## Check
 
-Run the script:
+Run:
 
 ```powershell
 py .\universal_calendar_homework.py
 ```
 
-Check the S3 path has partition folders like this:
+Then check the table in Athena:
+
+```sql
+SELECT *
+FROM "data-and-insight-refined-zone"."test_your_name_demo_calendar_monthly_partitioned"
+LIMIT 10;
+```
+
+You should also see partition folders in S3, for example:
 
 ```text
 import_year=2026/import_month=5/import_day=19/import_date=2026-05-19/
 ```
-
-Check the table in Athena:
-
-```sql
-SELECT
-  import_year,
-  import_month,
-  import_day,
-  import_date,
-  count(*) AS row_count
-FROM "data-and-insight-refined-zone"."test_your_name_demo_calendar_monthly_partitioned"
-GROUP BY 1, 2, 3, 4
-ORDER BY 1, 2, 3, 4;
-```
-
-Expected result: one import partition for the day you ran the script.

--- a/docs/playbook/onboard-etl-at-dap/002-homework-partitioned-calendar-aggregate.md
+++ b/docs/playbook/onboard-etl-at-dap/002-homework-partitioned-calendar-aggregate.md
@@ -1,0 +1,123 @@
+---
+title: Homework - write a partitioned calendar aggregate
+description: "Homework for writing a different universal_calendar aggregate to a partitioned refined-zone Glue table."
+layout: playbook_js
+tags: [playbook]
+---
+
+## Goal
+
+Create a new Python script that reads:
+
+```sql
+"unrestricted-raw-zone"."universal_calendar"
+```
+
+Write a different aggregate to:
+
+```text
+s3://dataplatform-stg-refined-zone/data-and-insight/testing/demo/test_<your_name>_demo_calendar_monthly_partitioned/
+```
+
+Register this new Glue catalog table in the same database:
+
+```text
+"data-and-insight-refined-zone"."test_<your_name>_demo_calendar_monthly_partitioned"
+```
+
+Use your own name in the table name. For example, if your name is Jane Smith, use `test_jane_smith_demo_calendar_monthly_partitioned`. Do not use `tian` unless your name is Tian.
+
+The output must be partitioned by:
+
+```python
+["import_year", "import_month", "import_day", "import_date"]
+```
+
+## Task
+
+Copy `universal_calendar_demo.py` into a new file:
+
+```text
+universal_calendar_homework.py
+```
+
+Change the table constants:
+
+```python
+TABLE_NAME = "test_your_name_demo_calendar_monthly_partitioned"
+PARTITION_COLUMNS = ["import_year", "import_month", "import_day", "import_date"]
+```
+
+Use this different aggregate query:
+
+```sql
+SELECT
+  year(CAST(date_iso AS timestamp)) AS calendar_year,
+  month(CAST(date_iso AS timestamp)) AS calendar_month,
+  count(*) AS day_count,
+  sum(CASE WHEN bank_holiday_flag THEN 1 ELSE 0 END) AS bank_holiday_count,
+  sum(CASE WHEN holiday_flag THEN 1 ELSE 0 END) AS holiday_count
+FROM "unrestricted-raw-zone"."universal_calendar"
+WHERE date_iso IS NOT NULL
+GROUP BY 1, 2
+ORDER BY 1, 2
+```
+
+After reading the data into `df`, add these import partition columns:
+
+```python
+from datetime import date
+
+today = date.today()
+df["import_year"] = today.year
+df["import_month"] = today.month
+df["import_day"] = today.day
+df["import_date"] = today.isoformat()
+```
+
+Update the `wr.s3.to_parquet` call so it writes partitions:
+
+```python
+result = wr.s3.to_parquet(
+    df=df,
+    path=target_prefix,
+    index=False,
+    dataset=True,
+    mode="overwrite",
+    database=TARGET_DATABASE,
+    table=TABLE_NAME,
+    partition_cols=PARTITION_COLUMNS,
+    filename_prefix=f"{TABLE_NAME}_",
+    boto3_session=session,
+)
+```
+
+## Check Your Work
+
+Run the script:
+
+```powershell
+py .\universal_calendar_homework.py
+```
+
+Check the S3 path has partition folders like this:
+
+```text
+import_year=2026/import_month=5/import_day=19/import_date=2026-05-19/
+```
+
+Check the table in Athena:
+
+```sql
+SELECT
+  import_year,
+  import_month,
+  import_day,
+  import_date,
+  count(*) AS row_count
+FROM "data-and-insight-refined-zone"."test_your_name_demo_calendar_monthly_partitioned"
+GROUP BY 1, 2, 3, 4
+ORDER BY 1, 2, 3, 4;
+```
+
+Expected result: one import partition for the day you ran the script.

--- a/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
+++ b/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
@@ -1,0 +1,81 @@
+"""Demo ETL: read universal_calendar, aggregate it, and publish a Glue table."""
+
+import logging
+
+import boto3
+import awswrangler as wr
+
+
+PROFILE = "DataPlatformDataAndInsightStg"
+REGION = "eu-west-2"
+
+SOURCE_DATABASE = "unrestricted-raw-zone"
+SOURCE_TABLE = "universal_calendar"
+
+TARGET_DATABASE = "data-and-insight-refined-zone"
+TARGET_BUCKET = "dataplatform-stg-refined-zone"
+TABLE_NAME = "test_tian_demo_calendar"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def create_session():
+    return boto3.Session(profile_name=PROFILE, region_name=REGION)
+
+
+def get_target_prefix():
+    return f"s3://{TARGET_BUCKET}/data-and-insight/testing/demo/{TABLE_NAME}/"
+
+
+def get_calendar_aggregate_query():
+    return f"""
+    SELECT
+      year(CAST(date_iso AS timestamp)) AS calendar_year,
+      count(*) AS day_count,
+      sum(CASE WHEN bank_holiday_flag THEN 1 ELSE 0 END) AS bank_holiday_count,
+      sum(CASE WHEN holiday_flag THEN 1 ELSE 0 END) AS holiday_count
+    FROM "{SOURCE_DATABASE}"."{SOURCE_TABLE}"
+    WHERE date_iso IS NOT NULL
+    GROUP BY 1
+    ORDER BY 1
+    """
+
+
+def read_calendar_aggregate(session):
+    return wr.athena.read_sql_query(
+        sql=get_calendar_aggregate_query(),
+        database=SOURCE_DATABASE,
+        ctas_approach=False,
+        boto3_session=session,
+    )
+
+
+def write_calendar_table(df, session, target_prefix):
+    wr.s3.delete_objects(path=target_prefix, boto3_session=session)
+    return wr.s3.to_parquet(
+        df=df,
+        path=target_prefix,
+        index=False,
+        dataset=True,
+        mode="overwrite",
+        database=TARGET_DATABASE,
+        table=TABLE_NAME,
+        filename_prefix=f"{TABLE_NAME}_",
+        boto3_session=session,
+    )
+
+
+def main():
+    session = create_session()
+    target_prefix = get_target_prefix()
+    df = read_calendar_aggregate(session)
+    result = write_calendar_table(df, session, target_prefix)
+
+    logger.info("Wrote %s rows to %s", len(df), target_prefix)
+    logger.info("Registered table %s.%s", TARGET_DATABASE, TABLE_NAME)
+    logger.info("Parquet files: %s", result["paths"])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
+++ b/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
@@ -2,9 +2,8 @@
 
 import logging
 
-import boto3
 import awswrangler as wr
-
+import boto3
 
 PROFILE = "DataPlatformDataAndInsightStg"
 REGION = "eu-west-2"

--- a/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
+++ b/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
@@ -26,10 +26,6 @@ def create_session():
     return boto3.Session(profile_name=PROFILE, region_name=REGION)
 
 
-def get_target_prefix():
-    return f"s3://{TARGET_BUCKET}/data-and-insight/testing/demo/{TABLE_NAME}/"
-
-
 def get_calendar_aggregate_query():
     return f"""
     SELECT
@@ -71,7 +67,7 @@ def write_calendar_table(df, session, target_prefix):
 
 def main():
     session = create_session()
-    target_prefix = get_target_prefix()
+    target_prefix = f"s3://{TARGET_BUCKET}/data-and-insight/testing/demo/{TABLE_NAME}/"
     df = read_calendar_aggregate(session, ATHENA_OUTPUT_PREFIX)
     result = write_calendar_table(df, session, target_prefix)
 

--- a/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
+++ b/docs/playbook/onboard-etl-at-dap/universal_calendar_demo.py
@@ -14,6 +14,9 @@ SOURCE_TABLE = "universal_calendar"
 TARGET_DATABASE = "data-and-insight-refined-zone"
 TARGET_BUCKET = "dataplatform-stg-refined-zone"
 TABLE_NAME = "test_tian_demo_calendar"
+ATHENA_OUTPUT_PREFIX = (
+    f"s3://dataplatform-stg-athena-storage/data-and-insight/{TABLE_NAME}/"
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -41,11 +44,12 @@ def get_calendar_aggregate_query():
     """
 
 
-def read_calendar_aggregate(session):
+def read_calendar_aggregate(session, athena_output_prefix):
     return wr.athena.read_sql_query(
         sql=get_calendar_aggregate_query(),
         database=SOURCE_DATABASE,
         ctas_approach=False,
+        s3_output=athena_output_prefix,
         boto3_session=session,
     )
 
@@ -68,7 +72,7 @@ def write_calendar_table(df, session, target_prefix):
 def main():
     session = create_session()
     target_prefix = get_target_prefix()
-    df = read_calendar_aggregate(session)
+    df = read_calendar_aggregate(session, ATHENA_OUTPUT_PREFIX)
     result = write_calendar_table(df, session, target_prefix)
 
     logger.info("Wrote %s rows to %s", len(df), target_prefix)

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,10 +23,15 @@ module.exports = {
       type: "category",
       label: "Playbook",
       items: [
-      {
+        {
           type: "category",
           label: "Getting set up on the platform",
           items: getItems("playbook/getting-set-up"),
+        },
+        {
+          type: "category",
+          label: "Onboard ETL at DAP",
+          items: getItems("playbook/onboard-etl-at-dap"),
         },
         {
           type: "category",


### PR DESCRIPTION
## Description

Adds a simple onboarding example for engineers showing how to read `universal_calendar`, aggregate it, write Parquet to the refined zone, and register a Glue catalog table using `awswrangler`.

Includes:
- A runnable Python script for the demo ETL.
- A short playbook guide with Windows AWS SSO setup and run instructions.
- A new sidebar entry for `Onboard ETL at DAP`.
- Verified the script writes and re-runs successfully in `stg`.