### PR TITLE
Update manual CSV upload playbooks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/data-analytics-platform
+* @LBHackney-IT/data-analytics-platform @LBHackney-IT/data-insight

--- a/docs/playbook/ingesting-data/003-manual-ingest-of-csv-files.md
+++ b/docs/playbook/ingesting-data/003-manual-ingest-of-csv-files.md
@@ -1,9 +1,21 @@
 ---
-title: Ingest manually uploaded csv files
+title: "[Deprecated] Ingest manually uploaded CSV files"
 description: "Ingest data from csv files"
 layout: playbook_js
 tags: [playbook]
 ---
+
+:::danger DEPRECATED
+
+This playbook describes the legacy manual CSV ingestion workflow and should
+not be used for new uploads. Use
+[Ingest manually uploaded CSV files into the Glue Catalog](./014-CSV-files-to-Glue-Catalog-automation.md)
+instead.
+
+This page is retained as a reference for people who previously used this
+workflow.
+
+:::
 
 ## Prerequisites
 

--- a/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
+++ b/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
@@ -23,82 +23,106 @@ a user from an enabled department uploads or removes CSV files in the
 Upload files to your departmental prefix inside the production bucket:
 
 ```
-s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<table_name>/<file_name>.csv
+s3://dataplatform-prod-user-uploads/<department>/<target_table_name>/<file_name>.csv
 ```
 
 - `<department>` identifies your team (e.g. `parking`, `housing`).
-- `<project_name_prefix>` is a required folder because it becomes the first
-  part of the Glue table name. Using a project or data-source name is
-  recommended (e.g. `parking_permits`, `ringgo`). For individual work, you can
-  use the uploader's name instead (e.g. `davina`).
-- `<table_name>` is a subfolder for one table (e.g. `permits`). A project folder
-  can contain multiple table subfolders.
-- `<file_name>` is the CSV for that table (e.g. `permits_march.csv`).
-- Only `.csv` files are supported; other extensions are rejected.
+- `<target_table_name>` is the folder immediately below the department and
+  becomes the Glue table name (e.g. `ringgo_permits`).
+- `<file_name>` is ignored when generating the Glue table name. Every CSV in
+  the same `<target_table_name>` folder contributes data to the same table.
+- Only lowercase `.csv` files are processed; other extensions are ignored.
 
 ### Table Names
 
 The table name is generated automatically as:
 
 ```
-normalize(<project_name_prefix>) + "_" + normalize(<table_name>)
+normalize(<target_table_name>)
 ```
 
 Normalization replaces non-alphanumeric characters with underscores and
 collapses consecutive underscores into one.
 
+### Required Path
+
+The Lambda accepts exactly one table folder beneath the department:
+
+```text
+<department>/<target_table_name>/<file_name>.csv
+```
+
+CSV files that do not match this path structure are rejected, an error is
+logged, and no Glue table is created. Other file types do not trigger this
+automation. For example:
+
+```text
+parking/permits.csv                         # Missing target table folder
+parking/ringgo/permits/permits.csv         # Too many folders
+parking/ringgo_permits/permits.xlsx        # Unsupported and not processed
+```
+
 ## Notes
 
 - _Visibility:_ Every member of your department can currently see the CSV
   files and Glue tables created from these uploads, not just those stored under
-  a particular `<project_name_prefix>`.
+  a particular `<target_table_name>`.
 - _Schema:_ All columns in the generated Glue tables are currently created as `string` types.
-- _Upload location:_ Create a separate `<table_name>` subfolder for every table
-  inside the project folder. Keep one CSV file in each table subfolder.
-- _Existing uploads:_ The legacy
-  `<department>/<project_name_prefix>/<file_name>.csv` layout remains supported,
-  but it should not be used for multiple tables because all files share the
-  same S3 table location.
+- _Table isolation:_ Each `<target_table_name>` folder is a separate table and
+  has its own S3 location.
+- _Multiple files:_ CSV files in the same table folder must have the same
+  header and schema because Athena reads them together as one table.
+- _Data format:_ The CSV files are not converted to Parquet. Athena reads the
+  original CSV files directly from the user uploads bucket.
 
 ### Using Parking as an Example
 
-Parking users can create two tables in the same `ringgo` project folder:
+Parking users can upload monthly files to the same table folder:
 
 ```
-s3://dataplatform-prod-user-uploads/parking/ringgo/permits/permits_march.csv
-s3://dataplatform-prod-user-uploads/parking/ringgo/payments/payments_march.csv
+s3://dataplatform-prod-user-uploads/parking/ringgo_permits/january.csv
+s3://dataplatform-prod-user-uploads/parking/ringgo_permits/february.csv
 ```
 
-These generate `ringgo_permits` and `ringgo_payments` inside the
-`parking_user_uploads_db` Glue database. Each table points only to its own
-table subfolder.
+These two files jointly make up `ringgo_permits`; they do not create two
+tables. The table is created inside the `parking_user_uploads_db` Glue database
+and points to the `parking/ringgo_permits/` S3 folder.
+
+To create a separate table, use another table folder:
+
+```text
+s3://dataplatform-prod-user-uploads/parking/ringgo_payments/payments.csv
+```
+
+This creates the separate `ringgo_payments` table.
 
 ## 3. Upload CSV files (Console)
 
 1. Sign in to the AWS Console and open **S3**.
 2. Navigate to the `dataplatform-prod-user-uploads` bucket.
 3. Browse into your department folder (e.g. `parking/`).
-4. Inside the `<department>` folder, create a subfolder named after the project
-   or data source (`<project_name_prefix>`), then open it.
-5. Inside the project folder, create a subfolder for the table
-   (`<table_name>`), then open it.
-6. Click **Upload** → **Add files** and choose the CSV for that table.
-7. Leave the default permissions and encryption settings unchanged.
-8. Click **Upload**.
+4. Inside the `<department>` folder, create a subfolder named after the target
+   table (`<target_table_name>`), then open it.
+5. Click **Upload** → **Add files** and choose one or more CSV files that have
+   the same header and schema.
+6. Leave the default permissions and encryption settings unchanged.
+7. Click **Upload**.
 
 Processing takes less than a minute. When complete:
 
 - The CSV is stored at
-  `<department>/<project_name_prefix>/<table_name>/<file_name>.csv`.
+  `<department>/<target_table_name>/<file_name>.csv`.
 - A Glue table with the generated name appears in the department upload
   database (currently `parking_user_uploads_db` for the Parking workflow).
 - You can query the table immediately in Athena.
 
 ## 4. Delete CSV files (Console)
 
-Deleting the CSV removes the corresponding Glue table.
+Deleting a CSV removes the Glue table only when no other CSV files remain in
+the same `<target_table_name>` folder.
 
 1. In S3, select the CSV under
-   `<department>/<project_name_prefix>/<table_name>/`.
+   `<department>/<target_table_name>/`.
 2. Choose **Delete** and confirm.
-3. Within less than a minute the table disappears from Glue/Athena.
+3. If it was the final CSV in the folder, the table disappears from Glue/Athena
+   within less than a minute. Otherwise, the table remains.

--- a/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
+++ b/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
@@ -1,42 +1,45 @@
 ---
-title: CSV files to Glue Catalog automation
+title: Ingest manually uploaded CSV files into the Glue Catalog
 description: "Automatically create or delete AWS Glue Catalog tables when CSV files are uploaded or removed from S3"
 layout: playbook_js
 tags: [playbook]
 ---
 
-# CSV files to Glue Catalog automation
+# Ingest manually uploaded CSV files into the Glue Catalog
 
 This Lambda automatically creates or deletes AWS Glue Catalog tables whenever
-any departmental user uploads or removes CSV files in the
+a user from an enabled department uploads or removes CSV files in the
 `dataplatform-prod-user-uploads` S3 bucket.
 
 ## 1. Prerequisites
 
 - CSV files with a single header row at the top.
+- The automation is currently enabled for Parking, Housing, Data and Insight,
+  Child Fam Services, Unrestricted, Environmental Services, and Revenues. If
+  you need it enabled for another department, contact the Data Platform team.
 
 ## 2. Folder Structure & File Naming
 
 Upload files to your departmental prefix inside the production bucket:
 
 ```
-s3://dataplatform-prod-user-uploads/<department>/<user_prefix>/<file_name>.csv
+s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<file_name>.csv
 ```
 
 - `<department>` identifies your team (e.g. `parking`, `housing`).
-- `<user_prefix>` **must** be a folder named after the uploader (e.g.
-  `davina`, `mike`). Each uploader should keep their files under their own
-  prefix.
+- `<project_name_prefix>` is a required folder because it becomes the first
+  part of the Glue table name. Using a project or data-source name is
+  recommended (e.g. `parking_permits`, `ringgo`). For individual work, you can
+  use the uploader's name instead (e.g. `davina`).
 - `<file_name>` should describe the data set (e.g. `permits_march.csv`).
 - Only `.csv` files are supported; other extensions are rejected.
-
 
 ### Table Names
 
 The table name is generated automatically as:
 
 ```
-normalize(<user_name>) + "_" + normalize(<file_name without .csv>)
+normalize(<project_name_prefix>) + "_" + normalize(<file_name without .csv>)
 ```
 
 Normalization replaces non-alphanumeric characters with underscores and
@@ -44,42 +47,49 @@ collapses consecutive underscores into one.
 
 ## Notes
 
-- _Visibility:_ Every member of your department can currently see the CSV files and Glue tables created from these uploads, not just those stored under their own `<user_prefix>`.
+- _Visibility:_ Every member of your department can currently see the CSV
+  files and Glue tables created from these uploads, not just those stored under
+  a particular `<project_name_prefix>`.
 - _Schema:_ All columns in the generated Glue tables are currently created as `string` types.
-- _Upload location:_ Place one or more CSV files per upload. Not allowed to add additional subfolders beneath your `<user_prefix>` folder.
+- _Upload location:_ Place one or more CSV files beneath the project prefix.
+  Avoid additional subfolders because they do not become part of the table
+  name and can cause table-name collisions.
 
 ### Using Parking as an Example
 
 Parking users upload to:
 
 ```
-s3://dataplatform-prod-user-uploads/parking/davina/permits_march.csv
+s3://dataplatform-prod-user-uploads/parking/ringgo/permits_march.csv
 ```
 
-This generates the table `davina_permits_march` inside the
+This generates the table `ringgo_permits_march` inside the
 `parking_user_uploads_db` Glue database.
-
 
 ## 3. Upload CSV files (Console)
 
 1. Sign in to the AWS Console and open **S3**.
 2. Navigate to the `dataplatform-prod-user-uploads` bucket.
 3. Browse into your department folder (e.g. `parking/`).
-4. Create a folder named after yourself (if it doesn’t already exist) and open it.
+4. Inside the `<department>` folder, create a subfolder named after the project
+   or data source (`<project_name_prefix>`), then open it.
 5. Click **Upload** → **Add files** and choose your CSV files.
-6. Leave default for everything else (e.g. permissions/encryption (SSE-S3), etc.).
+6. Leave the default permissions and encryption settings unchanged.
 7. Click **Upload**.
 
 Processing takes less than a minute. When complete:
 
-- The CSV is stored at `<department>/<user_prefix>/<file_name>.csv`.
+- The CSV is stored at
+  `<department>/<project_name_prefix>/<file_name>.csv`.
 - A Glue table with the generated name appears in the department upload
   database (currently `parking_user_uploads_db` for the Parking workflow).
 - You can query the table immediately in Athena.
 
 ## 4. Delete CSV files (Console)
+
 Deleting the CSV removes the corresponding Glue table.
 
-1. In S3, select the CSV under `<department>/<user_prefix>/`.
+1. In S3, select the CSV under
+   `<department>/<project_name_prefix>/`.
 2. Choose **Delete** and confirm.
 3. Within less than a minute the table disappears from Glue/Athena.

--- a/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
+++ b/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
@@ -15,15 +15,15 @@ a user from an enabled department uploads or removes CSV files in the
 
 - CSV files with a single header row at the top.
 - The automation is currently enabled for Parking, Housing, Data and Insight,
-  Child Fam Services, Unrestricted, Environmental Services, and Revenues. If
-  you need it enabled for another department, contact the Data Platform team.
+  Child Fam Services, Environmental Services, and Revenues. If you need it
+  enabled for another department, contact the Data Platform team.
 
 ## 2. Folder Structure & File Naming
 
 Upload files to your departmental prefix inside the production bucket:
 
 ```
-s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<file_name>.csv
+s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<table_name>/<file_name>.csv
 ```
 
 - `<department>` identifies your team (e.g. `parking`, `housing`).
@@ -31,7 +31,9 @@ s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<file_nam
   part of the Glue table name. Using a project or data-source name is
   recommended (e.g. `parking_permits`, `ringgo`). For individual work, you can
   use the uploader's name instead (e.g. `davina`).
-- `<file_name>` should describe the data set (e.g. `permits_march.csv`).
+- `<table_name>` is a subfolder for one table (e.g. `permits`). A project folder
+  can contain multiple table subfolders.
+- `<file_name>` is the CSV for that table (e.g. `permits_march.csv`).
 - Only `.csv` files are supported; other extensions are rejected.
 
 ### Table Names
@@ -39,7 +41,7 @@ s3://dataplatform-prod-user-uploads/<department>/<project_name_prefix>/<file_nam
 The table name is generated automatically as:
 
 ```
-normalize(<project_name_prefix>) + "_" + normalize(<file_name without .csv>)
+normalize(<project_name_prefix>) + "_" + normalize(<table_name>)
 ```
 
 Normalization replaces non-alphanumeric characters with underscores and
@@ -51,20 +53,25 @@ collapses consecutive underscores into one.
   files and Glue tables created from these uploads, not just those stored under
   a particular `<project_name_prefix>`.
 - _Schema:_ All columns in the generated Glue tables are currently created as `string` types.
-- _Upload location:_ Place one or more CSV files beneath the project prefix.
-  Avoid additional subfolders because they do not become part of the table
-  name and can cause table-name collisions.
+- _Upload location:_ Create a separate `<table_name>` subfolder for every table
+  inside the project folder. Keep one CSV file in each table subfolder.
+- _Existing uploads:_ The legacy
+  `<department>/<project_name_prefix>/<file_name>.csv` layout remains supported,
+  but it should not be used for multiple tables because all files share the
+  same S3 table location.
 
 ### Using Parking as an Example
 
-Parking users upload to:
+Parking users can create two tables in the same `ringgo` project folder:
 
 ```
-s3://dataplatform-prod-user-uploads/parking/ringgo/permits_march.csv
+s3://dataplatform-prod-user-uploads/parking/ringgo/permits/permits_march.csv
+s3://dataplatform-prod-user-uploads/parking/ringgo/payments/payments_march.csv
 ```
 
-This generates the table `ringgo_permits_march` inside the
-`parking_user_uploads_db` Glue database.
+These generate `ringgo_permits` and `ringgo_payments` inside the
+`parking_user_uploads_db` Glue database. Each table points only to its own
+table subfolder.
 
 ## 3. Upload CSV files (Console)
 
@@ -73,14 +80,16 @@ This generates the table `ringgo_permits_march` inside the
 3. Browse into your department folder (e.g. `parking/`).
 4. Inside the `<department>` folder, create a subfolder named after the project
    or data source (`<project_name_prefix>`), then open it.
-5. Click **Upload** → **Add files** and choose your CSV files.
-6. Leave the default permissions and encryption settings unchanged.
-7. Click **Upload**.
+5. Inside the project folder, create a subfolder for the table
+   (`<table_name>`), then open it.
+6. Click **Upload** → **Add files** and choose the CSV for that table.
+7. Leave the default permissions and encryption settings unchanged.
+8. Click **Upload**.
 
 Processing takes less than a minute. When complete:
 
 - The CSV is stored at
-  `<department>/<project_name_prefix>/<file_name>.csv`.
+  `<department>/<project_name_prefix>/<table_name>/<file_name>.csv`.
 - A Glue table with the generated name appears in the department upload
   database (currently `parking_user_uploads_db` for the Parking workflow).
 - You can query the table immediately in Athena.
@@ -90,6 +99,6 @@ Processing takes less than a minute. When complete:
 Deleting the CSV removes the corresponding Glue table.
 
 1. In S3, select the CSV under
-   `<department>/<project_name_prefix>/`.
+   `<department>/<project_name_prefix>/<table_name>/`.
 2. Choose **Delete** and confirm.
 3. Within less than a minute the table disappears from Glue/Athena.

--- a/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
+++ b/docs/playbook/ingesting-data/014-CSV-files-to-Glue-Catalog-automation.md
@@ -108,13 +108,13 @@ This creates the separate `ringgo_payments` table.
 6. Leave the default permissions and encryption settings unchanged.
 7. Click **Upload**.
 
-Processing takes less than a minute. When complete:
+After the upload is complete, the automated processing takes less than a
+minute. When processing is complete, Parking users can query the table in
+Athena as:
 
-- The CSV is stored at
-  `<department>/<target_table_name>/<file_name>.csv`.
-- A Glue table with the generated name appears in the department upload
-  database (currently `parking_user_uploads_db` for the Parking workflow).
-- You can query the table immediately in Athena.
+```text
+parking_user_uploads_db.<target_table_name>
+```
 
 ## 4. Delete CSV files (Console)
 


### PR DESCRIPTION
## Summary

This PR introduces a playbook for uploading CSV files through the AWS Console and automatically creating Glue Catalog tables.

## Changes

- Documents the required `<department>/<target_table_name>/<file_name>.csv` structure.
- Explains that the table folder determines the Glue table name and the CSV filename is ignored.
- Clarifies that multiple CSV files in the same folder jointly form one table.
- Includes valid and invalid path examples.
- Explains when the table becomes available in Athena.
- Clarifies that Athena queries the original CSV files without converting them to Parquet.
- Marks the previous manual CSV ingestion playbook as deprecated.
- Adds Data and Insight as a code owner.